### PR TITLE
Remove quantecon from environment.yml and requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,4 @@ dependencies:
   - pandas
   - matplotlib
   - pip:
-    - quantecon
     - jupyter-book>=0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 sphinx == 2.4.4
 pandas
 matplotlib
-quantecon
 jupyter-book == 0.7.1


### PR DESCRIPTION
This PR removes the `quantecon` package from the `environment.yml` and `requirements.txt` files. This is due to an error in the GitHub Action with the `setup.py` that I think is required to install the `quantecon` package.