### PR TITLE
Updated environment to python=3.7.7 and jupyter-book==0.7.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,10 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python>=3.7.4
+  - python=3.7.7
   - sphinx>=2.4.4
   - pip
   - pandas
   - matplotlib
   - pip:
-    - jupyter-book>=0.7.3
+    - jupyter-book==0.7.3


### PR DESCRIPTION
This PR updates the Python version in `environment.yml` to `python=3.7.7` and updates the `jupyter-book` version in `environment.yml` to be 0.7.3 which matches the version in `requirements.txt`.