### PR TITLE
Got rid of navbar numbering in _toc.yml for now

### DIFF
--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -1,7 +1,7 @@
 name: Build and Deploy Jupyter Book
 on:
   push:
-    branches:    
+    branches:
       - master
 jobs:
   build-and-deploy:

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -1,5 +1,4 @@
 - file: content/intro
-  numbered: true
 
 - chapter: Git and GitHub Background and History
   sections:

--- a/book/content/intro.md
+++ b/book/content/intro.md
@@ -76,42 +76,8 @@ In the online version of this book, the table of contents can be toggled to be v
 
 Introduction
 
-* Ch. 1: [Git and GitHub Tutorial Introduction](https://pslmodels.github.io/Git-Tutorial/content/intro.html)
-
-Git and GitHub Background
-
-* Ch. 2: [History of Git](https://pslmodels.github.io/Git-Tutorial/content/background/GitHistory.html)
-* Ch. 3: [History of GitHub](https://pslmodels.github.io/Git-Tutorial/content/background/GitHubHistory.html)
-* Ch. 4: [Git vs. Google Docs and Dropbox](https://pslmodels.github.io/Git-Tutorial/content/background/GoogleDropbox.html)
-
-Using Git and GitHub
-
-* Ch. 5: Installing Git
-* Ch. 6: Setting up Git with git config
-* Ch. 7: Create GitHub account
-* Ch. 8: Git and GitHub basics
-* Ch. 9: Git and GitHub collaborative workflow
-* Ch. 10: Merge conflicts and file diffs
-* Ch. 11: Issue threads and PR threads
-* Ch. 12: Advanced Git and GitHub
-* Ch. 13: Git and GitHub cheat sheet
-
-Open Source Repository Management
-
-* Ch. 14: Open source license options
-* Ch. 15: Continuous integration and unit testing
-* Ch. 16: Documentation
-* Ch. 17: Virtual environments
-
-Test Editor Git Configuration
-
-* Ch. 18: Text editors and Git overview
-* Ch. 19: VS Code Git configuration
-
-Appendix
-
-* Ch. 20: [Glossary](https://pslmodels.github.io/Git-Tutorial/content/glossary.html)
-* Ch. 21: [Bibliography](https://pslmodels.github.io/Git-Tutorial/content/bibliography.html)
+```{tableofcontents}
+```
 
 The contribution of this book to the large body of Git and GitHub references is to bring together in one place the tools and specific instruction for a beginning to move up the Git learning curve as quickly as possible. This is the only resource we know of that combines Git and GitHub functionality and usage with the tools of open source repository management. This is the guide that we wish we had had when we were learning to collaborate with Git and GitHub.
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python=3.7.7
+  - python==3.7.7
   - sphinx>=2.4.4
   - pip
   - pandas


### PR DESCRIPTION
This PR removes the `numbered: true` flag at the top of the `_toc.yml` file because it does not work properly yet in `jupyter-book` version 0.7.3. I had a somewhat extensive issue thread on the `jupyter-book` repository ([Issue #822](https://github.com/executablebooks/jupyter-book/issues/822)), and it looks like they will fix this soon. The corresponding issue in this repo is Issue #16. But until it is fixed in `jupyter-book, we have removed the chapter numbering.

This PR:
* removes the chapter numbering in the `_toc.yml`
* replaces the table of contents outline in `intro.md` with the `{tableofcontents}` method
