### PR TITLE
Update static site and cleanup

### DIFF
--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -26,8 +26,8 @@ jobs:
         run: make book
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: book/_build/site # The folder the action should deploy.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: book/_build/html

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -27,6 +27,9 @@ jobs:
         env:
           BASE_URL: /Git-Tutorial
 
+      - name: Add .nojekyll
+        run: touch book/_build/html/.nojekyll
+
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Build book
         run: make book
+        env:
+          BASE_URL: /Git-Tutorial
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: book
+.PHONY: book serve
 
 book:
-	cd book && uv run jupyter book clean --all --yes && uv run jupyter book build --all
+	cd book && uv run jupyter book clean --all --yes && uv run jupyter book build --html
+
+serve:
+	cd book && uv run jupyter book clean --all --yes && uv run jupyter book build --site && uv run jupyter book start

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: book serve
+.PHONY: book serve clean
 
 book:
-	cd book && uv run jupyter book clean --all --yes && uv run jupyter book build --html
+	cd book && uv run jupyter book build --html
 
 serve:
-	cd book && uv run jupyter book clean --all --yes && uv run jupyter book build --site && uv run jupyter book start
+	cd book && uv run jupyter book start
+
+clean:
+	cd book && uv run jupyter book clean --all --yes

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ make book
 
 The `book` target first removes the existing Jupyter Book build artifacts and then performs a fresh site build using `uv run jupyter book build --all`.
 
+You can run the `make serve` command to do all the steps from `make book`, but further initiate a local server on which you can view, check, and validate the functioning web site.
+
+```bash
+make serve
+```
+
+
 ## Notes
 
 This repository is actively maintained and contributions are welcome. The most helpful contributions usually improve tutorial clarity, correct command examples, add beginner-friendly explanations, or expand the hands-on workflow chapters.

--- a/book/content/bibliography.md
+++ b/book/content/bibliography.md
@@ -1,5 +1,0 @@
-(chap_bibliog)=
-# Bibliography
-
-:::{bibliography}
-:::

--- a/book/myst.yml
+++ b/book/myst.yml
@@ -42,7 +42,6 @@ project:
     - title: Appendix
       children:
         - file: content/glossary.md
-        - file: content/bibliography.md
 
 site:
   template: book-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "git-tutorial-book"
-version = "0.1.0"
+version = "0.1.1"
 description = "Build configuration for the PSLmodels Git Tutorial book."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "git-tutorial-book"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "jupyter-book" },


### PR DESCRIPTION
Issue #36 notes that the site is not correctly deploying via the GH Action `deploy_jupyterbook.yml` upon merging a pull request. This is likely because the new workflow creates a dynamic JavaScript site (not static). GitHub pages must be static.

This PR:
- Updates the `Makefile`, `myst.yml`, and `deploy_jupyterbook.yml` to create a workflow that sends a static site to the `gh-pages` branch.
- Updates `myst.yml` and deletes the `bibliography.md` page because this new format publishes all our bibliographic references at the bottom of the page where the references occur.
- Adds a `make serve` command to the `Makefile` that allows you to see the website on a local server.

cc: @jdebacker 