### PR TITLE
Update project license to CC BY-NC-SA 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,45 @@
-BSD 3-Clause License
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 
-Copyright (c) 2020, PSLmodels/Git-Tutorial contributors
-All rights reserved.
+Copyright (c) 2026, PSLmodels/Git-Tutorial contributors
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License ("CC BY-NC-SA 4.0").
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+Plain-English summary
+=====================
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+You may:
 
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
+* copy and share this material in any medium or format
+* adapt, remix, transform, and build on this material
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+These permissions apply only if your use is non-commercial and you follow the license terms below.
+
+You must:
+
+* give appropriate attribution to PSLmodels/Git-Tutorial contributors
+* include a copyright notice
+* provide a link to the CC BY-NC-SA 4.0 license
+* indicate whether you made changes
+* distribute adaptations under the same CC BY-NC-SA 4.0 license or a Creative Commons compatible license
+
+You may not:
+
+* use this material for commercial purposes
+* apply additional legal or technical restrictions that would limit other people from exercising the rights granted by the license
+* imply that the licensors endorse you or your use of the material unless they have explicitly agreed to do so
+
+Additional notes
+================
+
+* This summary is provided for convenience and does not replace the full license.
+* Some uses may still require additional permissions if other rights are involved, such as privacy, publicity, or third-party rights.
+* Exceptions and limitations to copyright law, such as fair use, are not affected by this license.
+
+To view a copy of this license, visit:
+https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+Or send a letter to:
+Creative Commons
+PO Box 1866
+Mountain View, CA 94042
+USA

--- a/book/content/repomgt/license.md
+++ b/book/content/repomgt/license.md
@@ -3,6 +3,16 @@
 
 Choosing a license is one of the most important early decisions for an open-source repository. A license tells other people what they are allowed to do with the code and what obligations come with that use.
 
+## License used by this project
+
+The Git Tutorial project is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license (CC BY-NC-SA 4.0).
+
+The copyright notice for the project should read:
+
+`Copyright (c) 2026, PSLmodels/Git-Tutorial contributors`
+
+This is a more restrictive license than permissive software licenses such as BSD or MIT because it requires attribution, limits use to non-commercial purposes, and requires adapted versions to be shared under the same license terms.
+
 ## Why a license matters
 
 Without a license, a public GitHub repository may be visible, but others usually do not have clear legal permission to reuse, modify, or redistribute the code.
@@ -27,6 +37,10 @@ These licenses are often chosen when the project wants to maximize downstream ad
 ### Copyleft licenses
 
 Copyleft licenses such as GPL require derivative works to remain under compatible open-source terms when distributed. These licenses are often chosen when maintainers want changes to remain open in downstream redistributions.
+
+### Creative Commons licenses
+
+Creative Commons licenses are more commonly used for documentation, books, and other written or creative works than for software source code. A license such as CC BY-NC-SA 4.0 allows sharing and adaptation with attribution, restricts commercial use, and requires derivatives to use the same license.
 
 ## Questions maintainers should ask
 


### PR DESCRIPTION
## Summary

This PR updates the project licensing from BSD 3-Clause to Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0), and refreshes the copyright year to 2026.

## What changed

- updated the top-level `LICENSE` file
- changed the copyright notice to `2026`
- replaced the old BSD 3-Clause text with a CC BY-NC-SA 4.0 notice
- expanded the `LICENSE` file with a plain-English summary of:
  - what is permitted
  - what attribution and share-alike obligations apply
  - what is not permitted, especially commercial use
  - the note that the official Creative Commons license text controls
- updated `book/content/repomgt/license.md` so the book’s licensing discussion reflects the project’s current license choice

## Notes

- The `LICENSE` file now includes a readable summary plus the official Creative Commons license URL.
- The binding legal terms remain those of the official CC BY-NC-SA 4.0 license:
  https://creativecommons.org/licenses/by-nc-sa/4.0/